### PR TITLE
Fixed invalid gemspec with blank metadata URLs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,9 @@ inherit_gem:
 Gemspec/RequiredRubyVersion:
   Exclude:
     - "spec/support/fixtures/*.gemspec"
+Layout/RedundantLineBreak:
+  Exclude:
+    - "spec/support/fixtures/*.gemspec"
 Metrics/AbcSize:
   Exclude:
     - "lib/gemsmith/cli/shell.rb"

--- a/lib/gemsmith/builders/specification.rb
+++ b/lib/gemsmith/builders/specification.rb
@@ -20,6 +20,8 @@ module Gemsmith
 
         builder.call(config)
                .render
+               .replace("    \n", "")
+               .replace("      ", "    ")
                .replace("  \n", "")
                .replace("    spec", "  spec")
                .replace(/\}\s+s/m, "}\n\n  s")

--- a/lib/gemsmith/templates/%project_name%/%project_name%.gemspec.erb
+++ b/lib/gemsmith/templates/%project_name%/%project_name%.gemspec.erb
@@ -8,13 +8,25 @@ Gem::Specification.new do |spec|
   spec.license = "<%= configuration.license_label_version %>"
 
   spec.metadata = {
-    "bug_tracker_uri" => "<%= configuration.computed_project_url_issues %>",
-    "changelog_uri" => "<%= configuration.computed_project_url_versions %>",
-    "documentation_uri" => "<%= configuration.computed_project_url_home %>",
-    "funding_uri" => "<%= configuration.computed_project_url_funding %>",
+    <% unless configuration.computed_project_url_issues.empty? %>
+      "bug_tracker_uri" => "<%= configuration.computed_project_url_issues %>",
+    <% end %>
+    <% unless configuration.computed_project_url_versions.empty? %>
+      "changelog_uri" => "<%= configuration.computed_project_url_versions %>",
+    <% end %>
+    <% unless configuration.computed_project_url_home.empty? %>
+      "documentation_uri" => "<%= configuration.computed_project_url_home %>",
+    <% end %>
+    <% unless configuration.computed_project_url_funding.empty? %>
+      "funding_uri" => "<%= configuration.computed_project_url_funding %>",
+    <% end %>
     "label" => "<%= configuration.project_label %>",
-    "rubygems_mfa_required" => "true",
-    "source_code_uri" => "<%= configuration.computed_project_url_source %>"
+    <% if configuration.computed_project_url_source.empty? %>
+      "rubygems_mfa_required" => "true"
+    <% else %>
+      "rubygems_mfa_required" => "true",
+      "source_code_uri" => "<%= configuration.computed_project_url_source %>"
+    <% end %>
   }
 
   <% if configuration.build_security %>

--- a/spec/lib/gemsmith/builders/specification_spec.rb
+++ b/spec/lib/gemsmith/builders/specification_spec.rb
@@ -19,6 +19,28 @@ RSpec.describe Gemsmith::Builders::Specification do
 
       it "builds gemspec" do
         expect(temp_dir.join("test", "test.gemspec").read).to eq(
+          Bundler.root.join("spec/support/fixtures/test-minimum-metadata.gemspec").read
+        )
+      end
+    end
+
+    context "with minimum and no project URLs" do
+      let :test_configuration do
+        configuration.minimize.merge project_url_community: nil,
+                                     project_url_conduct: nil,
+                                     project_url_contributions: nil,
+                                     project_url_download: nil,
+                                     project_url_funding: nil,
+                                     project_url_home: nil,
+                                     project_url_issues: nil,
+                                     project_url_license: nil,
+                                     project_url_security: nil,
+                                     project_url_source: nil,
+                                     project_url_versions: nil
+      end
+
+      it "builds gemspec" do
+        expect(temp_dir.join("test", "test.gemspec").read).to eq(
           Bundler.root.join("spec/support/fixtures/test-minimum.gemspec").read
         )
       end

--- a/spec/support/fixtures/test-minimum-metadata.gemspec
+++ b/spec/support/fixtures/test-minimum-metadata.gemspec
@@ -1,0 +1,24 @@
+Gem::Specification.new do |spec|
+  spec.name = "test"
+  spec.version = "0.0.0"
+  spec.authors = ["Jill Smith"]
+  spec.email = ["jill@example.com"]
+  spec.homepage = "https://www.example.com/test"
+  spec.summary = ""
+  spec.license = "Hippocratic-2.1"
+
+  spec.metadata = {
+    "bug_tracker_uri" => "https://www.example.com/test/issues",
+    "changelog_uri" => "https://www.example.com/test/versions",
+    "documentation_uri" => "https://www.example.com/test",
+    "funding_uri" => "https://www.example.com/test/funding",
+    "label" => "Test",
+    "rubygems_mfa_required" => "true",
+    "source_code_uri" => "https://www.example.com/test/source"
+  }
+
+  spec.required_ruby_version = "~> 3.1"
+
+  spec.extra_rdoc_files = Dir["README*", "LICENSE*"]
+  spec.files = Dir["*.gemspec", "lib/**/*"]
+end

--- a/spec/support/fixtures/test-minimum.gemspec
+++ b/spec/support/fixtures/test-minimum.gemspec
@@ -3,18 +3,13 @@ Gem::Specification.new do |spec|
   spec.version = "0.0.0"
   spec.authors = ["Jill Smith"]
   spec.email = ["jill@example.com"]
-  spec.homepage = "https://www.example.com/test"
+  spec.homepage = ""
   spec.summary = ""
   spec.license = "Hippocratic-2.1"
 
   spec.metadata = {
-    "bug_tracker_uri" => "https://www.example.com/test/issues",
-    "changelog_uri" => "https://www.example.com/test/versions",
-    "documentation_uri" => "https://www.example.com/test",
-    "funding_uri" => "https://www.example.com/test/funding",
     "label" => "Test",
-    "rubygems_mfa_required" => "true",
-    "source_code_uri" => "https://www.example.com/test/source"
+    "rubygems_mfa_required" => "true"
   }
 
   spec.required_ruby_version = "~> 3.1"


### PR DESCRIPTION
## Overview

Necessary to ensure you don't get the following errors when building a
new gem but have not configured *any* project URLs:

    ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
    metadata['bug_tracker_uri'] has invalid link: ""

## Details

- Resolves #9 